### PR TITLE
Captures created by operator div().

### DIFF
--- a/library/lpeg.lua
+++ b/library/lpeg.lua
@@ -50,7 +50,7 @@ local lpeg = {}
 ---@operator add(Capture): Pattern
 ---@operator mul(Capture): Pattern
 ---@operator mul(Pattern): Pattern
----@operator pow(Capture): Pattern
+---@operator pow(number): Pattern
 ---
 ---The matching function.
 ---It attempts to match the given pattern against the subject string.

--- a/library/lpeg.lua
+++ b/library/lpeg.lua
@@ -42,6 +42,10 @@ local lpeg = {}
 ---@operator add(Pattern): Pattern
 ---@operator mul(Pattern): Pattern
 ---@operator mul(Capture): Pattern
+---@operator div(string): Capture
+---@operator div(number): Capture
+---@operator div(table): Capture
+---@operator div(function): Capture
 ---@operator pow(number): Pattern
 ---@field match fun(p: Pattern, s: string)
 
@@ -50,6 +54,10 @@ local lpeg = {}
 ---@operator add(Capture): Pattern
 ---@operator mul(Capture): Pattern
 ---@operator mul(Pattern): Pattern
+---@operator div(string): Capture
+---@operator div(number): Capture
+---@operator div(table): Capture
+---@operator div(function): Capture
 ---@operator pow(number): Pattern
 ---
 ---The matching function.


### PR DESCRIPTION
This PR adds operator div() that creates captrues.

In the following example, variables `p1`, `p2`, `p3`, and `p4` shall be captures.

```lua
local lpeg = require('lpeg')

-- string capture
local p1 = lpeg.P('a') / 'foo'
-- number capture
local p2 = (lpeg.C(lpeg.P('b')) * lpeg.C(lpeg.P('c'))) / 2
-- table capture
local p3 = lpeg.P('d') / { d = 'bar' }
-- function capture
local p4 = lpeg.R('09') / tonumber

local p = p1 * p2 * p3 * p4
local res = lpeg.match(lpeg.Ct(p), 'abcd3')

for k,v in pairs(res) do
   print(k, v, type(v))
end
```