### PR TITLE
Fix documentation mistake in lpeg.Cp()

### DIFF
--- a/library/lpeg.lua
+++ b/library/lpeg.lua
@@ -538,7 +538,7 @@ function lpeg.Cg(patt, name) end
 ---```lua
 ---local I = lpeg.Cp()
 ---local function anywhere(p) return lpeg.P({I * p * I + 1 * lpeg.V(1)}) end
-
+---
 ---local match_start, match_end = anywhere("world"):match("hello world!")
 ---assert(match_start == 7)
 ---assert(match_end == 12)


### PR DESCRIPTION
The documentation for `lpeg.Cp()` looked like this for me.

![image](https://github.com/LuaCATS/lpeg/assets/26823245/6e6e647e-092a-4258-b07e-1ef1f7955167)

This PR adds a `---` separator to connect the rest of the comments (scrollbar is present but hidden). 

![image](https://github.com/LuaCATS/lpeg/assets/26823245/0a329045-2561-4f8b-9472-dda878baceed)