### PR TITLE
changed parameter/return types of `lpeg.Cf`, `lpeg.match`, and `Pattern:match`

### DIFF
--- a/library/lpeg.lua
+++ b/library/lpeg.lua
@@ -105,7 +105,7 @@ local Pattern = {}
 ---@param subject string
 ---@param init? integer
 ---
----@return integer|Capture
+---@return any ...
 ---
 ---😱 [Types](https://github.com/LuaCATS/lpeg/blob/main/library/lpeg.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/lpeg/pulls)
 function lpeg.match(pattern, subject, init) end
@@ -145,7 +145,7 @@ function lpeg.match(pattern, subject, init) end
 ---@param subject string
 ---@param init? integer
 ---
----@return integer|Capture
+---@return any ...
 ---
 ---😱 [Types](https://github.com/LuaCATS/lpeg/blob/main/library/lpeg.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/lpeg/pulls)
 function Pattern:match(subject, init) end

--- a/library/lpeg.lua
+++ b/library/lpeg.lua
@@ -502,7 +502,7 @@ function lpeg.Cc(...) end
 ---```
 ---
 ---@param patt Pattern
----@param func fun(acc, newvalue)
+---@param func fun(acc, newvalue): (acc: any)
 ---
 ---@return Capture
 ---


### PR DESCRIPTION
- `lpeg.Cf`'s function argument should allow at least one return value, the language server currently says it shouldn't return anything due to the `redundant-return-value` lint.

```lua
local lpeg = require("lpeg")
local Cf, Cc, C, S = lpeg.Cf, lpeg.Cc, lpeg.C, lpeg.S

local Indent = Cf(Cc(0) * C(S(" \t")), function(sum, v)
  return sum + (v == " " and 1 or 4)
  --     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ lint appears here
end
```

- `lpeg.match` and `Pattern:match` return `...any`, because LPeg returns an integer if there are no captures, but returns a tuple of capture values if there are any. Capture values can be anything, even `nil`, due to the flexibility of `lpeg.Cc`, so both `match` functions don't have a very consistent return value in practice.